### PR TITLE
Update REVColorSensorV3_template.json to use HTTPS

### DIFF
--- a/REVColorSensorV3_template.json
+++ b/REVColorSensorV3_template.json
@@ -4,9 +4,9 @@
     "version": "__VERSION_HERE__",
     "uuid": "cda7b4b1-d003-44ac-a1ef-485c1347059a",
     "mavenUrls": [
-        "http://www.revrobotics.com/content/sw/max/sdk/maven/"
+        "https://www.revrobotics.com/content/sw/max/sdk/maven/"
     ],
-    "jsonUrl": "http://www.revrobotics.com/content/sw/max/sdk/REVColorSensorV3.json",
+    "jsonUrl": "https://www.revrobotics.com/content/sw/max/sdk/REVColorSensorV3.json",
     "javaDependencies": [
         {
             "groupId": "com.revrobotics.frc",


### PR DESCRIPTION
Swap to HTTPS for security and to fix deprecation warning in Gradle.

```
Using insecure protocols with repositories, without explicit opt-in, has been deprecated. This is scheduled to be removed in Gradle 7.0.
Switch Maven repository 'WPI3f48eb8c-50fe-43a6-9cb7-44c86353c4cb_0Release(http://www.revrobotics.com/content/sw/max/sdk/maven/)' to a secure protocol (like HTTPS) or allow insecure protocols.
See https://docs.gradle.org/6.8/dsl/org.gradle.api.artifacts.repositories.UrlArtifactRepository.html#org.gradle.api.artifacts.repositories.UrlArtifactRepository:allowInsecureProtocol for more details.
```

This has been successfully tested by manually making the same changes in the .json file of a local project and rebuilding it.